### PR TITLE
Handle negative loads in demand calculator

### DIFF
--- a/tests/test_parse_load.py
+++ b/tests/test_parse_load.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from demand import parse_load
+
+
+def test_negative_values_return_zero():
+    assert parse_load("-50", 240) == 0
+
+
+def test_amp_to_watt_conversion():
+    assert parse_load("50", 240) == 50 * 240 * 0.8
+
+
+def test_blank_returns_zero():
+    assert parse_load("   ", 240) == 0
+
+
+def test_values_over_500_treated_as_watts():
+    assert parse_load("600", 240) == 600
+
+
+def test_value_500_treated_as_amps():
+    assert parse_load("500", 240) == 500 * 240 * 0.8


### PR DESCRIPTION
## Summary
- Treat negative or non-numeric load inputs as zero
- Wrap UI bootstrapping in `if __name__ == "__main__"` so helpers can be imported
- Interpret values ≤500 as breaker amps and larger values as watts
- Add unit tests for load parsing including new threshold behavior

## Testing
- `pip install pillow`
- `pip install reportlab`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b85afe4b88331aa7a03393a827a13