### PR TITLE
Add simple Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Demand-Calculator
+
+This project provides tools to compute the electrical demand for single dwellings.
+
+## Web application
+
+A minimal Flask app is included to run the calculator in a browser.
+
+### Running
+
+```
+pip install flask
+python app.py
+```
+
+Then open [http://localhost:5000](http://localhost:5000) to use the calculator.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,54 @@
+from flask import Flask, render_template, request
+from calculator.core import parse_load, calculate_demand
+
+app = Flask(__name__)
+
+
+def _parse_list(raw: str, voltage: float):
+    """Parse comma separated loads using parse_load."""
+    items = []
+    for part in raw.split(','):
+        part = part.strip()
+        if part:
+            items.append(parse_load(part, voltage))
+    return items
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    result = None
+    error = None
+    if request.method == 'POST':
+        try:
+            voltage = float(request.form.get('voltage', '0'))
+            area = float(request.form.get('area', '0'))
+            range_w = parse_load(request.form.get('range', ''), voltage)
+            heat_w = parse_load(request.form.get('heat', ''), voltage)
+            ac_w = parse_load(request.form.get('ac', ''), voltage)
+            evse_w = parse_load(request.form.get('evse', ''), voltage)
+            interlocked = bool(request.form.get('interlocked'))
+            add_all = _parse_list(request.form.get('additional', ''), voltage)
+            add_list = [w for w in add_all if w > 1500]
+            tankless_w = parse_load(request.form.get('tankless', ''), voltage)
+            sps_all = _parse_list(request.form.get('sps', ''), voltage)
+
+            inputs, results, debug = calculate_demand(
+                voltage=voltage,
+                area_main=area,
+                range_main_w=range_w,
+                heat_main_w=heat_w,
+                ac_main_w=ac_w,
+                evse_main_w=evse_w,
+                interlocked=interlocked,
+                add_main_list_w=add_list,
+                tankless_main_w=tankless_w,
+                sps_main_all=sps_all,
+            )
+            result = results
+        except Exception as exc:
+            error = str(exc)
+    return render_template('index.html', result=result, error=error)
+
+
+if __name__ == '__main__':
+    app.run()

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<title>Demand Calculator</title>
+<h1>Demand Calculator</h1>
+{% if error %}
+<p style="color:red;">{{ error }}</p>
+{% endif %}
+<form method="post">
+  <label>Voltage:
+    <input type="number" step="any" name="voltage" required value="{{ request.form.voltage or '240' }}">
+  </label><br>
+  <label>Main Area (m²):
+    <input type="number" step="any" name="area" required value="{{ request.form.area or '' }}">
+  </label><br>
+  <label>Range (A or W):
+    <input type="text" name="range" value="{{ request.form.range or '' }}">
+  </label><br>
+  <label>Heating (A or W):
+    <input type="text" name="heat" value="{{ request.form.heat or '' }}">
+  </label><br>
+  <label>AC (A or W):
+    <input type="text" name="ac" value="{{ request.form.ac or '' }}">
+  </label><br>
+  <label>EVSE (A or W):
+    <input type="text" name="evse" value="{{ request.form.evse or '' }}">
+  </label><br>
+  <label>Interlocked Heat/AC:
+    <input type="checkbox" name="interlocked" {% if request.form.get('interlocked') %}checked{% endif %}>
+  </label><br>
+  <label>Additional Loads >1500W (comma separated):
+    <input type="text" name="additional" value="{{ request.form.additional or '' }}">
+  </label><br>
+  <label>Tankless WH (A or W):
+    <input type="text" name="tankless" value="{{ request.form.tankless or '' }}">
+  </label><br>
+  <label>Steamers/Pools/Spas (comma separated):
+    <input type="text" name="sps" value="{{ request.form.sps or '' }}">
+  </label><br>
+  <button type="submit">Calculate</button>
+</form>
+{% if result %}
+<h2>Result</h2>
+<p>{{ result['Final Calculated Load (W)'] }} W</p>
+{% endif %}

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,24 @@
+from app import app
+
+
+def test_index_get():
+    client = app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200
+
+
+def test_index_post():
+    client = app.test_client()
+    resp = client.post('/', data={
+        'voltage': '240',
+        'area': '100',
+        'range': '40',
+        'heat': '0',
+        'ac': '0',
+        'evse': '0',
+        'additional': '',
+        'tankless': '',
+        'sps': ''
+    })
+    assert resp.status_code == 200
+    assert b'Result' in resp.data


### PR DESCRIPTION
## Summary
- create Flask-based web app wrapping demand calculation
- provide HTML form to collect loads and display results
- document web app usage and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc4cde0188331a2c5312d34263b9f