### PR TITLE
Add suite and sqft support with dynamic load inputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,16 @@
 from flask import Flask, render_template, request
+from flask import Flask, render_template, request
 from calculator.core import parse_load, calculate_demand
 
 app = Flask(__name__)
 
 
-def _parse_list(raw: str, voltage: float):
-    """Parse comma separated loads using parse_load."""
+def _parse_list(values, voltage: float):
+    """Parse a list of string load entries using parse_load."""
+    if isinstance(values, str):
+        values = [values]
     items = []
-    for part in raw.split(','):
+    for part in values:
         part = part.strip()
         if part:
             items.append(parse_load(part, voltage))
@@ -21,16 +24,42 @@ def index():
     if request.method == 'POST':
         try:
             voltage = float(request.form.get('voltage', '0'))
-            area = float(request.form.get('area', '0'))
+
+            area_raw = float(request.form.get('area', '0'))
+            area_unit = request.form.get('area_unit', 'm2')
+            area = area_raw * 0.092903 if area_unit == 'ft2' else area_raw
+
             range_w = parse_load(request.form.get('range', ''), voltage)
             heat_w = parse_load(request.form.get('heat', ''), voltage)
             ac_w = parse_load(request.form.get('ac', ''), voltage)
             evse_w = parse_load(request.form.get('evse', ''), voltage)
             interlocked = bool(request.form.get('interlocked'))
-            add_all = _parse_list(request.form.get('additional', ''), voltage)
+
+            add_all = _parse_list(request.form.getlist('additional'), voltage)
             add_list = [w for w in add_all if w > 1500]
             tankless_w = parse_load(request.form.get('tankless', ''), voltage)
-            sps_all = _parse_list(request.form.get('sps', ''), voltage)
+            sps_all = _parse_list(request.form.getlist('sps'), voltage)
+
+            suite = None
+            if request.form.get('suite'):
+                suite_area_raw = float(request.form.get('suite_area', '0'))
+                suite_area = suite_area_raw * 0.092903 if area_unit == 'ft2' else suite_area_raw
+                suite_range_w = parse_load(request.form.get('suite_range', ''), voltage)
+                suite_evse_w = parse_load(request.form.get('suite_evse', ''), voltage)
+                suite_add_all = _parse_list(request.form.getlist('suite_additional'), voltage)
+                suite_add_list = [w for w in suite_add_all if w > 1500]
+                suite_tankless_w = parse_load(request.form.get('suite_tankless', ''), voltage)
+                suite_sps_all = _parse_list(request.form.getlist('suite_sps'), voltage)
+                suite = {
+                    'area': suite_area,
+                    'range_w': suite_range_w,
+                    'evse_w': suite_evse_w,
+                    'add_loads': suite_add_list,
+                    'tankless_w': suite_tankless_w,
+                    'sps': suite_sps_all,
+                }
+                if area_unit == 'ft2':
+                    suite['area_ft2'] = suite_area_raw
 
             inputs, results, debug = calculate_demand(
                 voltage=voltage,
@@ -43,6 +72,8 @@ def index():
                 add_main_list_w=add_list,
                 tankless_main_w=tankless_w,
                 sps_main_all=sps_all,
+                area_main_ft2=area_raw if area_unit == 'ft2' else None,
+                suite=suite,
             )
             result = results
         except Exception as exc:

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,38 +6,127 @@
 {% endif %}
 <form method="post">
   <label>Voltage:
-    <input type="number" step="any" name="voltage" required value="{{ request.form.voltage or '240' }}">
+    <input type="number" step="any" name="voltage" required value="240">
   </label><br>
-  <label>Main Area (m²):
-    <input type="number" step="any" name="area" required value="{{ request.form.area or '' }}">
+
+  <label>Area Unit:
+    <select name="area_unit" id="area-unit">
+      <option value="m2" selected>m²</option>
+      <option value="ft2">ft²</option>
+    </select>
   </label><br>
+
+  <label>Main Area (<span class="area-unit-label">m²</span>):
+    <input type="number" step="any" name="area" required value="">
+  </label><br>
+
   <label>Range (A or W):
-    <input type="text" name="range" value="{{ request.form.range or '' }}">
+    <input type="text" name="range" value="">
   </label><br>
   <label>Heating (A or W):
-    <input type="text" name="heat" value="{{ request.form.heat or '' }}">
+    <input type="text" name="heat" value="">
   </label><br>
   <label>AC (A or W):
-    <input type="text" name="ac" value="{{ request.form.ac or '' }}">
+    <input type="text" name="ac" value="">
   </label><br>
   <label>EVSE (A or W):
-    <input type="text" name="evse" value="{{ request.form.evse or '' }}">
+    <input type="text" name="evse" value="">
   </label><br>
   <label>Interlocked Heat/AC:
-    <input type="checkbox" name="interlocked" {% if request.form.get('interlocked') %}checked{% endif %}>
+    <input type="checkbox" name="interlocked">
   </label><br>
-  <label>Additional Loads >1500W (comma separated):
-    <input type="text" name="additional" value="{{ request.form.additional or '' }}">
-  </label><br>
+
+  <label>Additional Loads >1500W:</label><br>
+  <div id="additional-main-fields">
+      <input type="text" name="additional" value=""><br>
+  </div>
+
   <label>Tankless WH (A or W):
-    <input type="text" name="tankless" value="{{ request.form.tankless or '' }}">
+    <input type="text" name="tankless" value="">
   </label><br>
-  <label>Steamers/Pools/Spas (comma separated):
-    <input type="text" name="sps" value="{{ request.form.sps or '' }}">
+
+  <label>Steamers/Pools/Spas:</label><br>
+  <div id="sps-main-fields">
+      <input type="text" name="sps" value=""><br>
+  </div>
+
+  <label>Include Suite:
+    <input type="checkbox" name="suite" id="suite-checkbox">
   </label><br>
+
+  <div id="suite-section" style="display:none; margin-left:20px;">
+    <label>Suite Area (<span class="area-unit-label">m²</span>):
+      <input type="number" step="any" name="suite_area" value="">
+    </label><br>
+    <label>Suite Range (A or W):
+      <input type="text" name="suite_range" value="">
+    </label><br>
+    <label>Suite EVSE (A or W):
+      <input type="text" name="suite_evse" value="">
+    </label><br>
+    <label>Suite Additional Loads >1500W:</label><br>
+    <div id="additional-suite-fields">
+        <input type="text" name="suite_additional" value=""><br>
+    </div>
+    <label>Suite Tankless WH (A or W):
+      <input type="text" name="suite_tankless" value="">
+    </label><br>
+    <label>Suite Steamers/Pools/Spas:</label><br>
+    <div id="sps-suite-fields">
+        <input type="text" name="suite_sps" value=""><br>
+    </div>
+  </div>
+
   <button type="submit">Calculate</button>
 </form>
+
 {% if result %}
 <h2>Result</h2>
-<p>{{ result['Final Calculated Load (W)'] }} W</p>
+<p>{{ result }} W</p>
 {% endif %}
+
+<script>
+function setupDynamic(containerId, name, max=10){
+  const container=document.getElementById(containerId);
+  function check(){
+    const inputs=container.querySelectorAll('input[name="'+name+'"]');
+    const last=inputs[inputs.length-1];
+    if(last.value.trim()!=='' && inputs.length<max){
+      const br=document.createElement('br');
+      const inp=document.createElement('input');
+      inp.type='text';
+      inp.name=name;
+      inp.addEventListener('input', check);
+      container.appendChild(inp);
+      container.appendChild(br);
+    }
+  }
+  container.querySelectorAll('input[name="'+name+'"]').forEach(inp=>inp.addEventListener('input', check));
+}
+
+function updateAreaLabels(){
+  const unit=document.getElementById('area-unit').value==='ft2'?'ft²':'m²';
+  document.querySelectorAll('.area-unit-label').forEach(el=>el.textContent=unit);
+}
+
+function toggleSuite(){
+  const section=document.getElementById('suite-section');
+  const checked=document.getElementById('suite-checkbox').checked;
+  section.style.display=checked?'block':'none';
+}
+
+document.addEventListener('DOMContentLoaded', function(){
+  if (performance.getEntriesByType('navigation')[0].type === 'reload') {
+    document.querySelector('form').reset();
+  }
+  setupDynamic('additional-main-fields','additional');
+  setupDynamic('sps-main-fields','sps');
+  setupDynamic('additional-suite-fields','suite_additional');
+  setupDynamic('sps-suite-fields','suite_sps');
+  updateAreaLabels();
+  toggleSuite();
+  document.getElementById('area-unit').addEventListener('change', updateAreaLabels);
+  document.getElementById('suite-checkbox').addEventListener('change', toggleSuite);
+});
+</script>
+


### PR DESCRIPTION
## Summary
- allow entering areas in square feet with automatic m² conversion
- add optional suite input section mirroring main dwelling fields
- replace comma-separated load entry with dynamic input boxes for additional loads and spas
- clear form inputs on browser refresh to avoid stale data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d2271fb488331927ade93f49cecbf